### PR TITLE
Making columns of DataFrame rdered

### DIFF
--- a/operations/cleaning/sort/README.MD
+++ b/operations/cleaning/sort/README.MD
@@ -1,0 +1,28 @@
+# sort
+
+## Overview
+
+### Description
+sort a matrix/map based on given columns 
+
+### Implementation details
+
+Input
+    Data - map[string]interface{} or [][]interface{}
+        Optional=False
+Params
+    Ascending - [boolean]
+    Axis - int : 0=vertical/column, 1=horizontal/row
+        Optional=True
+        Default=0
+    By - []interface{} : elements 1. conlumn label (string) or 2. column number (int from 0)
+	NaPosition - Puts NaNs at the beginning if first; last puts NaNs at the end.
+		Allows {"first", "last"}, Default "last"
+
+OutputType - map[string]interface{}
+
+
+## Compliance to Spec
+
+### Rough level of compliance  
+100%

--- a/operations/cleaning/sort/metadata.go
+++ b/operations/cleaning/sort/metadata.go
@@ -1,0 +1,26 @@
+package sort
+
+import (
+	//	"fmt"
+
+	"github.com/project-flogo/catalystml-flogo/operations/common"
+)
+
+type Params struct {
+	Ascending   bool          `md:"ascending"`
+	NilPosition string        `md:"nilPosition",allowed=["first","last"],required=false`
+	KeepRow     bool          `md:"keepRow"`
+	By          []interface{} `md:"by"`
+	Axis        int           `md:"axis"`
+}
+
+type Input struct {
+	Data interface{} `md:"data"`
+}
+
+func (i *Input) FromMap(values map[string]interface{}) error {
+	var err error
+	i.Data, err = common.ToDataFrame(values["data"])
+
+	return err
+}

--- a/operations/cleaning/sort/operation.go
+++ b/operations/cleaning/sort/operation.go
@@ -74,14 +74,14 @@ func (operation *Operation) Eval(inputs map[string]interface{}) (interface{}, er
 		dataFrame,
 	)
 
-	//operation.logger.Info("Before ------------->", sorter)
+	operation.logger.Debug("Before sort : ", sorter)
 	sort.Sort(sorter)
-	//operation.logger.Info("After  ------------->", sorter)
+	operation.logger.Debug("After sorted : ", sorter)
 
 	result = sorter.GetDataFrame()
 
 	operation.logger.Info("Operation Sort completed.")
-	operation.logger.Info("The output of Operation Sort.", result)
+	operation.logger.Info("The output of Operation Sort, As DataFrame : ", result)
 
 	return result.AsIs(), err
 }

--- a/operations/cleaning/sort/operation.go
+++ b/operations/cleaning/sort/operation.go
@@ -1,0 +1,142 @@
+package sort
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/project-flogo/catalystml-flogo/action/operation"
+	"github.com/project-flogo/catalystml-flogo/operations/common"
+
+	//	"github.com/project-flogo/core/data/coerce"
+	"github.com/project-flogo/core/data/metadata"
+	"github.com/project-flogo/core/support/log"
+)
+
+type Operation struct {
+	sortByKey bool
+	params    *Params
+	logger    log.Logger
+}
+
+func New(ctx operation.InitContext) (operation.Operation, error) {
+	p := &Params{}
+
+	err := metadata.MapToStruct(ctx.Params(), p, true)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Operation{params: p, logger: ctx.Logger()}, nil
+}
+
+func (operation *Operation) Eval(inputs map[string]interface{}) (interface{}, error) {
+
+	var err error
+	in := &Input{}
+
+	err = in.FromMap(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	if "first" != operation.params.NilPosition {
+		operation.params.NilPosition = "last"
+	}
+
+	switch operation.params.By[0].(type) {
+	case string:
+		operation.sortByKey = true
+	case int:
+		operation.sortByKey = false
+	}
+
+	dataFrame, ok := in.Data.(*common.DataFrame)
+
+	operation.logger.Info("Starting Operation Sort.")
+	operation.logger.Info("DataFrame is...", in.Data)
+	operation.logger.Info("Sort By...", operation.params.By)
+	operation.logger.Info("Axis is...", operation.params.Axis)
+	operation.logger.Info("Ascending is...", operation.params.Ascending)
+	operation.logger.Info("NilPosition is...", operation.params.NilPosition)
+	operation.logger.Info("sortByKey is...", operation.sortByKey)
+
+	if !ok {
+		errors.New("Input data should be DataFrame type.")
+	}
+
+	var result interface{}
+	switch operation.params.Axis {
+	case 0:
+		result, err = operation.sortByCol(dataFrame)
+	case 1:
+		result, err = operation.sortByRow(dataFrame)
+	}
+
+	if nil != err {
+		return nil, err
+	}
+
+	operation.logger.Info("Operation Sort completed.")
+	operation.logger.Info("The output of Operation Sort.", result)
+
+	return result, err
+}
+
+func (operation *Operation) sortByRow(dataFrame *common.DataFrame) (*common.DataFrame, error) {
+	tuples := common.TupleSorter{
+		Ascending: operation.params.Ascending,
+		NilLast:   "last" == operation.params.NilPosition,
+		ByKey:     operation.sortByKey,
+		SortBy:    operation.params.By,
+		Tuples:    make([]common.SortableTuple, 0),
+	}
+
+	for _, key := range dataFrame.GetKeys() {
+		data := append(dataFrame.GetColumn(key), key)
+		tuples.Tuples = append(tuples.Tuples, common.SortableTuple{
+			Data: data,
+		})
+	}
+
+	sort.Sort(tuples)
+
+	newDataFrame := common.NewDataFrame()
+	for _, sTuple := range tuples.Tuples {
+		newDataFrame.AddColumn(sTuple.Data[len(sTuple.Data)-1].(string), sTuple.Data[:len(sTuple.Data)-1])
+	}
+
+	return newDataFrame, nil
+}
+
+func (operation *Operation) sortByCol(dataFrame *common.DataFrame) (*common.DataFrame, error) {
+	tuples := common.TupleSorter{
+		Ascending: operation.params.Ascending,
+		NilLast:   "last" == operation.params.NilPosition,
+		ByKey:     operation.sortByKey,
+		SortBy:    operation.params.By,
+		Tuples:    make([]common.SortableTuple, 0),
+	}
+
+	keys := dataFrame.GetKeys()
+
+	newDataFrame, _ := common.ProcessDataFrame(dataFrame, func(tuple map[string]interface{}, newDataFrame *common.DataFrame, lastTuple bool) error {
+
+		tuples.Tuples = append(tuples.Tuples, common.NewSortableTuple(tuple, keys))
+
+		if lastTuple {
+			sort.Sort(tuples)
+			for _, sTuple := range tuples.Tuples {
+				newTuple := make(map[string]interface{})
+
+				for key, index := range sTuple.KeyToIndex {
+					newTuple[key] = sTuple.Data[index]
+				}
+				common.TupleAppendToDataframe(newTuple, newDataFrame)
+			}
+		}
+		return nil
+	})
+
+	return newDataFrame, nil
+}

--- a/operations/cleaning/sort/operation_test.go
+++ b/operations/cleaning/sort/operation_test.go
@@ -1,0 +1,466 @@
+package sort
+
+import (
+	"testing"
+
+	"github.com/project-flogo/catalystml-flogo/action/support/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortBySingleCol(t *testing.T) {
+	/*
+		>>> df = pd.DataFrame({
+		...     'col1': ['A', 'A', 'B', np.nan, 'D', 'C'],
+		...     'col2': [2, 1, 9, 8, 7, 4],
+		...     'col3': [0, 1, 9, 4, 2, 3],
+		... })
+		>>> df
+		   col1 col2 col3
+		0   A    2    0
+		1   A    1    1
+		2   B    9    9
+		3   NaN  8    4
+		4   D    7    2
+		5   C    4    3
+
+		>>> df.sort_values(by=['col1'])
+		    col1 col2 col3
+		0   A    2    0
+		1   A    1    1
+		2   B    9    9
+		5   C    4    3
+		4   D    7    2
+		3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{"col1"},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestSortByMultipleCols(t *testing.T) {
+
+	/*
+	   >>> df.sort_values(by=['col1', 'col2'])
+	       col1 col2 col3
+	   1   A    1    1
+	   0   A    2    0
+	   2   B    9    9
+	   5   C    4    3
+	   4   D    7    2
+	   3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{"col1", "col2"},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestSortByMultipleColsByIndex(t *testing.T) {
+
+	/*
+	   >>> df.sort_values(by=[0, 1])
+	       col1 col2 col3
+	   1   A    1    1
+	   0   A    2    0
+	   2   B    9    9
+	   5   C    4    3
+	   4   D    7    2
+	   3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0, 1},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestSortDescending(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=False)
+	       col1 col2 col3
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	   3   NaN  8    4
+	*/
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending: false,
+		KeepRow:   true,
+		By:        []interface{}{"col1"},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestDescentingNilFirst(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=False, na_position='first')
+	       col1 col2 col3
+	   3   NaN  8    4
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending:   false,
+		NilPosition: "first",
+		KeepRow:     true,
+		By:          []interface{}{"col1"},
+		Axis:        0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestAscentingNilFirst(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=True, na_position='first')
+	       col1 col2 col3
+	   3   NaN  8    4
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending:   true,
+		NilPosition: "first",
+		KeepRow:     true,
+		By:          []interface{}{"col1"},
+		Axis:        0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}
+
+func TestSortByRow(t *testing.T) {
+	/*
+		   >>> sorted=df.sort_values(by=1,axis=1)
+			   col2 col3 col1
+			0   2    0    A
+			1   1    1    A
+			2   9    9    B
+			3  	8    4    NaN
+			4   7    2    D
+			5   4    3    C
+	*/
+
+	inputs := make(map[string]interface{})
+	dataFrame := make(map[string]interface{})
+	inputs["data"] = dataFrame
+
+	dataFrame["order"] = []interface{}{
+		"col1", "col2", "col3",
+	}
+	dataFrame["col1"] = []interface{}{
+		"A", "A", "B", nil, "D", "C",
+	}
+	dataFrame["col2"] = []interface{}{
+		2, 1, 9, 8, 7, 4,
+	}
+	dataFrame["col3"] = []interface{}{
+		0, 1, 9, 4, 2, 3,
+	}
+
+	/*
+		inputs := make(map[string]interface{})
+		dataFrame := make([][]interface{})
+		inputs["data"] = dataFrame
+
+		dataFrame[0] = []interface{"col1", "col2", "col3"}
+
+		dataFrame[1] = []interface{}{
+			"A", "A", "B", "", "D", "C",
+		}
+		dataFrame[2] = []interface{}{
+			"2, 1, 9, 8, 7, 4,
+		}
+		dataFrame[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{1},
+		Axis:      1,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	_, err = opt.Eval(inputs)
+	assert.Nil(t, err)
+}

--- a/operations/cleaning/sort/operation_test.go
+++ b/operations/cleaning/sort/operation_test.go
@@ -405,13 +405,13 @@ func TestAscentingNilFirst(t *testing.T) {
 func TestSortByRow(t *testing.T) {
 	/*
 		   >>> sorted=df.sort_values(by=1,axis=1)
-			   col2 col3 col1
-			0   2    0    A
+			    col3 col2 col1
+			0   0    2    A
 			1   1    1    A
 			2   9    9    B
-			3  	8    4    NaN
-			4   7    2    D
-			5   4    3    C
+			3  	4    8    NaN
+			4   2    7    D
+			5   3    4    C
 	*/
 
 	inputs := make(map[string]interface{})

--- a/operations/cleaning/sort/operation_test.go
+++ b/operations/cleaning/sort/operation_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSortBySingleCol(t *testing.T) {
+func TestSortTableBySingleCol(t *testing.T) {
 	/*
 		>>> df = pd.DataFrame({
 		...     'col1': ['A', 'A', 'B', np.nan, 'D', 'C'],
@@ -34,39 +34,21 @@ func TestSortBySingleCol(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending: true,
@@ -80,11 +62,15 @@ func TestSortBySingleCol(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestSortByMultipleCols(t *testing.T) {
+func TestSortTableByMultipleCols(t *testing.T) {
 
 	/*
 	   >>> df.sort_values(by=['col1', 'col2'])
@@ -98,39 +84,21 @@ func TestSortByMultipleCols(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending: true,
@@ -144,11 +112,15 @@ func TestSortByMultipleCols(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestSortByMultipleColsByIndex(t *testing.T) {
+func TestSortTableByMultipleColsByIndex(t *testing.T) {
 
 	/*
 	   >>> df.sort_values(by=[0, 1])
@@ -162,39 +134,21 @@ func TestSortByMultipleColsByIndex(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending: true,
@@ -208,11 +162,15 @@ func TestSortByMultipleColsByIndex(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestSortDescending(t *testing.T) {
+func TestTableSortDescending(t *testing.T) {
 	/*
 	   >>> df.sort_values(by='col1', ascending=False)
 	       col1 col2 col3
@@ -223,40 +181,23 @@ func TestSortDescending(t *testing.T) {
 	   1   A    1    1
 	   3   NaN  8    4
 	*/
-	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
 
-	dataFrame["order"] = []interface{}{
+	inputs := make(map[string]interface{})
+	table := make(map[string]interface{})
+	inputs["data"] = table
+
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending: false,
@@ -270,11 +211,15 @@ func TestSortDescending(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestDescentingNilFirst(t *testing.T) {
+func TestSortTableDescentingNilFirst(t *testing.T) {
 	/*
 	   >>> df.sort_values(by='col1', ascending=False, na_position='first')
 	       col1 col2 col3
@@ -287,39 +232,21 @@ func TestDescentingNilFirst(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending:   false,
@@ -334,11 +261,15 @@ func TestDescentingNilFirst(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestAscentingNilFirst(t *testing.T) {
+func TestSortTableAscentingNilFirst(t *testing.T) {
 	/*
 	   >>> df.sort_values(by='col1', ascending=True, na_position='first')
 	       col1 col2 col3
@@ -351,39 +282,21 @@ func TestAscentingNilFirst(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending:   true,
@@ -398,11 +311,15 @@ func TestAscentingNilFirst(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
 }
 
-func TestSortByRow(t *testing.T) {
+func TestSortTableByRow(t *testing.T) {
 	/*
 		   >>> sorted=df.sort_values(by=1,axis=1)
 			    col3 col2 col1
@@ -415,39 +332,21 @@ func TestSortByRow(t *testing.T) {
 	*/
 
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string]interface{})
-	inputs["data"] = dataFrame
+	table := make(map[string]interface{})
+	inputs["data"] = table
 
-	dataFrame["order"] = []interface{}{
+	table["order"] = []interface{}{
 		"col1", "col2", "col3",
 	}
-	dataFrame["col1"] = []interface{}{
+	table["col1"] = []interface{}{
 		"A", "A", "B", nil, "D", "C",
 	}
-	dataFrame["col2"] = []interface{}{
+	table["col2"] = []interface{}{
 		2, 1, 9, 8, 7, 4,
 	}
-	dataFrame["col3"] = []interface{}{
+	table["col3"] = []interface{}{
 		0, 1, 9, 4, 2, 3,
 	}
-
-	/*
-		inputs := make(map[string]interface{})
-		dataFrame := make([][]interface{})
-		inputs["data"] = dataFrame
-
-		dataFrame[0] = []interface{"col1", "col2", "col3"}
-
-		dataFrame[1] = []interface{}{
-			"A", "A", "B", "", "D", "C",
-		}
-		dataFrame[2] = []interface{}{
-			"2, 1, 9, 8, 7, 4,
-		}
-		dataFrame[3] = []interface{}{
-			0, 1, 9, 4, 2, 3,
-		}
-	*/
 
 	params := Params{
 		Ascending: true,
@@ -461,6 +360,634 @@ func TestSortByRow(t *testing.T) {
 	opt, err := New(optInitConext)
 	assert.Nil(t, err)
 
-	_, err = opt.Eval(inputs)
+	out, err := opt.Eval(inputs)
 	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", table)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixBySingleCol(t *testing.T) {
+	/*
+		>>> df = pd.DataFrame({
+		...     'col1': ['A', 'A', 'B', np.nan, 'D', 'C'],
+		...     'col2': [2, 1, 9, 8, 7, 4],
+		...     'col3': [0, 1, 9, 4, 2, 3],
+		... })
+		>>> df
+		   col1 col2 col3
+		0   A    2    0
+		1   A    1    1
+		2   B    9    9
+		3   NaN  8    4
+		4   D    7    2
+		5   C    4    3
+
+		>>> df.sort_values(by=['col1'])
+		    col1 col2 col3
+		0   A    2    0
+		1   A    1    1
+		2   B    9    9
+		5   C    4    3
+		4   D    7    2
+		3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixByMultipleCols(t *testing.T) {
+
+	/*
+	   >>> df.sort_values(by=['col1', 'col2'])
+	       col1 col2 col3
+	   1   A    1    1
+	   0   A    2    0
+	   2   B    9    9
+	   5   C    4    3
+	   4   D    7    2
+	   3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0, 1},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixByMultipleColsByIndex(t *testing.T) {
+
+	/*
+	   >>> df.sort_values(by=[0, 1])
+	       col1 col2 col3
+	   1   A    1    1
+	   0   A    2    0
+	   2   B    9    9
+	   5   C    4    3
+	   4   D    7    2
+	   3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0, 1},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestMatrixSortDescending(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=False)
+	       col1 col2 col3
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	   3   NaN  8    4
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending: false,
+		KeepRow:   true,
+		By:        []interface{}{0},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixDescentingNilFirst(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=False, na_position='first')
+	       col1 col2 col3
+	   3   NaN  8    4
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending:   false,
+		NilPosition: "first",
+		KeepRow:     true,
+		By:          []interface{}{0},
+		Axis:        0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixAscentingNilFirst(t *testing.T) {
+	/*
+	   >>> df.sort_values(by='col1', ascending=True, na_position='first')
+	       col1 col2 col3
+	   3   NaN  8    4
+	   4   D    7    2
+	   5   C    4    3
+	   2   B    9    9
+	   0   A    2    0
+	   1   A    1    1
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending:   true,
+		NilPosition: "first",
+		KeepRow:     true,
+		By:          []interface{}{0},
+		Axis:        0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortMatrixByRow(t *testing.T) {
+	/*
+		   >>> sorted=df.sort_values(by=1,axis=1)
+			    col3 col2 col1
+			0   0    2    A
+			1   1    1    A
+			2   9    9    B
+			3  	4    8    NaN
+			4   2    7    D
+			5   3    4    C
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 2, 0,
+	}
+	matrix[1] = []interface{}{
+		0, 1, 1,
+	}
+	matrix[2] = []interface{}{
+		1, 9, 9,
+	}
+	matrix[3] = []interface{}{
+		nil, 8, 4,
+	}
+	matrix[4] = []interface{}{
+		3, 7, 2,
+	}
+	matrix[5] = []interface{}{
+		2, 4, 0,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{1},
+		Axis:      1,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortArrayByRow(t *testing.T) {
+	/*
+		   >>> sorted=df.sort_values(by=1,axis=1)
+			    col3 col2 col1
+			0   0    2    A
+			1   1    1    A
+			2   9    9    B
+			3  	4    8    NaN
+			4   2    7    D
+			5   3    4    C
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 6)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0,
+	}
+	matrix[1] = []interface{}{
+		0,
+	}
+	matrix[2] = []interface{}{
+		1,
+	}
+	matrix[3] = []interface{}{
+		nil,
+	}
+	matrix[4] = []interface{}{
+		3,
+	}
+	matrix[5] = []interface{}{
+		2,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0},
+		Axis:      0,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
+}
+
+func TestSortArrayByColumn(t *testing.T) {
+	/*
+		   >>> sorted=df.sort_values(by=1,axis=1)
+			    col3 col2 col1
+			0   0    2    A
+			1   1    1    A
+			2   9    9    B
+			3  	4    8    NaN
+			4   2    7    D
+			5   3    4    C
+	*/
+
+	inputs := make(map[string]interface{})
+	matrix := make([][]interface{}, 1)
+	inputs["data"] = matrix
+
+	/*
+		matrix[0] = []interface{}{"col1", "col2", "col3"}
+
+		matrix[1] = []interface{}{
+			"A", "A", "B", nil, "D", "C",
+		}
+		matrix[2] = []interface{}{
+			2, 1, 9, 8, 7, 4,
+		}
+		matrix[3] = []interface{}{
+			0, 1, 9, 4, 2, 3,
+		}
+	*/
+
+	matrix[0] = []interface{}{
+		0, 0, 1, nil, 3, 2,
+	}
+
+	params := Params{
+		Ascending: true,
+		KeepRow:   true,
+		By:        []interface{}{0},
+		Axis:      1,
+	}
+
+	optInitConext := test.NewOperationInitContext(params, nil)
+
+	opt, err := New(optInitConext)
+	assert.Nil(t, err)
+
+	out, err := opt.Eval(inputs)
+	assert.Nil(t, err)
+
+	t.Log("Input of Operation Sort : ", matrix)
+	t.Log("Output of Operation Sort : ", out)
+
 }

--- a/operations/common/common_test.go
+++ b/operations/common/common_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,6 @@ func TestSimpleMap2(t *testing.T) {
 	assert.Nil(t, err)
 
 }
-
 
 func TestSimpleMatrix(t *testing.T) {
 	matrixin := [][]int{[]int{1, 2}, []int{3, 4}, []int{5, 6}}
@@ -77,7 +77,7 @@ func TestProcessDataFrame(t *testing.T) {
 	newTuple := make(map[string]interface{})
 	newTuple["sum"] = 0
 	newTuple["count"] = 0
-	newDataFrame, _ := ProcessDataFrame(dataframe, func(tuple map[string]interface{}, newDataFrame *DataFrame, lastTuple bool) error {
+	newDataFrame, _ := ProcessDataFrame(*dataframe, func(tuple map[string]interface{}, newDataFrame *DataFrame, lastTuple bool) error {
 		newTuple["sum"] = newTuple["sum"].(int) + tuple["blah"].(int)
 		newTuple["count"] = newTuple["count"].(int) + 1
 		if lastTuple {
@@ -87,4 +87,108 @@ func TestProcessDataFrame(t *testing.T) {
 	})
 
 	fmt.Println(newDataFrame)
+}
+
+func TestSortableTuple(t *testing.T) {
+	tuples := TupleSorter{
+		ByKey:  true,
+		SortBy: []interface{}{"col1", "col2", "col3", "col4"},
+		Tuples: make([]SortableTuple, 4),
+	}
+
+	keyToIndex := map[string]int{
+		"col1": 0,
+		"col2": 1,
+		"col3": 2,
+		"col4": 3,
+	}
+
+	tuples.Tuples[0] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3718,
+			2138.0,
+			1908,
+			912},
+	}
+	tuples.Tuples[1] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3711,
+			2138.0,
+			1908,
+			912},
+	}
+	tuples.Tuples[2] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3718,
+			2138.0,
+			1940,
+			970},
+	}
+	tuples.Tuples[3] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3703,
+			2125.0,
+			1933,
+			943},
+	}
+
+	fmt.Println("Before : ", tuples)
+	sort.Sort(tuples)
+	fmt.Println("After  : ", tuples)
+}
+
+func TestSortableTupleByIndex(t *testing.T) {
+	tuples := TupleSorter{
+		ByKey:  false,
+		SortBy: []interface{}{0, 1, 2, 3},
+		Tuples: make([]SortableTuple, 4),
+	}
+
+	keyToIndex := map[string]int{
+		"col1": 0,
+		"col2": 1,
+		"col3": 2,
+		"col4": 3,
+	}
+
+	tuples.Tuples[0] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3718,
+			2138.0,
+			1908,
+			912},
+	}
+	tuples.Tuples[1] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3711,
+			2138.0,
+			1908,
+			912},
+	}
+	tuples.Tuples[2] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3718,
+			2138.0,
+			1940,
+			970},
+	}
+	tuples.Tuples[3] = SortableTuple{
+		KeyToIndex: keyToIndex,
+		Data: []interface{}{
+			3703,
+			2125.0,
+			1933,
+			943},
+	}
+
+	fmt.Println("Before : ", tuples)
+	sort.Sort(tuples)
+	fmt.Println("After  : ", tuples)
 }

--- a/operations/common/common_test.go
+++ b/operations/common/common_test.go
@@ -77,8 +77,9 @@ func TestProcessDataFrame(t *testing.T) {
 	newTuple := make(map[string]interface{})
 	newTuple["sum"] = 0
 	newTuple["count"] = 0
-	newDataFrame, _ := ProcessDataFrame(*dataframe, func(tuple map[string]interface{}, newDataFrame *DataFrame, lastTuple bool) error {
-		newTuple["sum"] = newTuple["sum"].(int) + tuple["blah"].(int)
+	newDataFrame := NewDataFrame()
+	ProcessDataFrame(dataframe, func(tuple *SortableTuple, lastTuple bool) error {
+		newTuple["sum"] = newTuple["sum"].(int) + tuple.GetByKey("blah").(int)
 		newTuple["count"] = newTuple["count"].(int) + 1
 		if lastTuple {
 			TupleAppendToDataframe(newTuple, newDataFrame)
@@ -90,105 +91,74 @@ func TestProcessDataFrame(t *testing.T) {
 }
 
 func TestSortableTuple(t *testing.T) {
-	tuples := TupleSorter{
-		ByKey:  true,
-		SortBy: []interface{}{"col1", "col2", "col3", "col4"},
-		Tuples: make([]SortableTuple, 4),
+
+	table := make(map[string]interface{})
+
+	table[DataFrameOrderLabel] = []interface{}{
+		"col1", "col2", "col3", "col4",
+	}
+	table["col1"] = []interface{}{
+		3718, 3711, 3718, 3703,
+	}
+	table["col2"] = []interface{}{
+		2138.0, 2138.0, 2138.0, 2125.0,
+	}
+	table["col3"] = []interface{}{
+		1908, 1908, 1940, 1933,
+	}
+	table["col4"] = []interface{}{
+		912, 912, 970, 943,
 	}
 
-	keyToIndex := map[string]int{
-		"col1": 0,
-		"col2": 1,
-		"col3": 2,
-		"col4": 3,
-	}
+	dataFrame, _ := ToDataFrame(table)
 
-	tuples.Tuples[0] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3718,
-			2138.0,
-			1908,
-			912},
-	}
-	tuples.Tuples[1] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3711,
-			2138.0,
-			1908,
-			912},
-	}
-	tuples.Tuples[2] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3718,
-			2138.0,
-			1940,
-			970},
-	}
-	tuples.Tuples[3] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3703,
-			2125.0,
-			1933,
-			943},
-	}
+	tuples := NewDataFrameSorter(
+		0,
+		true,
+		true,
+		true,
+		[]interface{}{"col1", "col2", "col3", "col4"},
+		dataFrame,
+	)
 
-	fmt.Println("Before : ", tuples)
+	fmt.Println("Before dataFrame : ", tuples.GetDataFrame())
 	sort.Sort(tuples)
-	fmt.Println("After  : ", tuples)
+	fmt.Println("After dataFrame : ", tuples.GetDataFrame())
 }
 
 func TestSortableTupleByIndex(t *testing.T) {
-	tuples := TupleSorter{
-		ByKey:  false,
-		SortBy: []interface{}{0, 1, 2, 3},
-		Tuples: make([]SortableTuple, 4),
+
+	table := make(map[string]interface{})
+
+	table[DataFrameOrderLabel] = []interface{}{
+		"col1", "col2", "col3", "col4",
+	}
+	table["col1"] = []interface{}{
+		3718, 3711, 3718, 3703,
+	}
+	table["col2"] = []interface{}{
+		2138.0, 2138.0, 2138.0, 2125.0,
+	}
+	table["col3"] = []interface{}{
+		1908, 1908, 1940, 1933,
+	}
+	table["col4"] = []interface{}{
+		912, 912, 970, 943,
 	}
 
-	keyToIndex := map[string]int{
-		"col1": 0,
-		"col2": 1,
-		"col3": 2,
-		"col4": 3,
-	}
+	dataFrame, _ := ToDataFrame(table)
 
-	tuples.Tuples[0] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3718,
-			2138.0,
-			1908,
-			912},
-	}
-	tuples.Tuples[1] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3711,
-			2138.0,
-			1908,
-			912},
-	}
-	tuples.Tuples[2] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3718,
-			2138.0,
-			1940,
-			970},
-	}
-	tuples.Tuples[3] = SortableTuple{
-		KeyToIndex: keyToIndex,
-		Data: []interface{}{
-			3703,
-			2125.0,
-			1933,
-			943},
-	}
+	tuples := NewDataFrameSorter(
+		0,
+		true,
+		true,
+		false,
+		[]interface{}{0, 1, 2, 3},
+		dataFrame,
+	)
 
-	fmt.Println("Before : ", tuples)
+	fmt.Println("Before dataFrame : ", tuples.GetDataFrame())
 	sort.Sort(tuples)
-	fmt.Println("After  : ", tuples)
+	fmt.Println("After dataFrame : ", tuples.GetDataFrame())
+
 }

--- a/operations/restructuring/groupBy/metadata.go
+++ b/operations/restructuring/groupBy/metadata.go
@@ -1,5 +1,9 @@
 package groupBy
 
+import (
+	"github.com/project-flogo/catalystml-flogo/operations/common"
+)
+
 type Params struct {
 	Index     []string            `md:"index"`
 	Aggregate map[string][]string `md:"aggregate"`
@@ -13,7 +17,7 @@ type Input struct {
 func (i *Input) FromMap(values map[string]interface{}) error {
 
 	var err error
-	i.Data, err = ToDataFrame(values["data"])
+	i.Data, err = common.ToDataFrame(values["data"])
 
 	return err
 }

--- a/operations/restructuring/groupBy/operation_test.go
+++ b/operations/restructuring/groupBy/operation_test.go
@@ -22,7 +22,7 @@ func Test0(t *testing.T) {
 		Parrot Captive       30.0
 		       Wild          20.0*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["Animal"] = []interface{}{
@@ -72,7 +72,7 @@ func Test1(t *testing.T) {
 		Falcon      370.0
 		Parrot       25.0*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["Animal"] = []interface{}{
@@ -122,7 +122,7 @@ func Test2(t *testing.T) {
 		Captive      210.0
 		Wild         185.0	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["Animal"] = []interface{}{
@@ -161,7 +161,7 @@ func Test2(t *testing.T) {
 
 func Test3(t *testing.T) {
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["Animal"] = []interface{}{

--- a/operations/restructuring/join/operation.go
+++ b/operations/restructuring/join/operation.go
@@ -53,8 +53,8 @@ func (operation *Operation) Eval(inputs map[string]interface{}) (interface{}, er
 	}
 
 	result, err = operation.join(
-		in.Left.(map[string][]interface{}),
-		in.Right.(map[string][]interface{}),
+		in.Left.(map[string]interface{}),
+		in.Right.(map[string]interface{}),
 		leftJoinOn,
 		rightJoinOn,
 	)
@@ -65,8 +65,8 @@ func (operation *Operation) Eval(inputs map[string]interface{}) (interface{}, er
 }
 
 func (operation *Operation) join(
-	leftDataFrame map[string][]interface{},
-	rightDataFrame map[string][]interface{},
+	leftDataFrame map[string]interface{},
+	rightDataFrame map[string]interface{},
 	leftIndex []string,
 	rightIndex []string,
 ) (result map[string][]interface{}, err error) {
@@ -91,7 +91,7 @@ func (operation *Operation) join(
 	/* check right tuple size */
 	tupleSize := -1
 	for fieldname, filedsArray := range dataFrame02 {
-		tupleSize = len(filedsArray)
+		tupleSize = len(filedsArray.([]interface{}))
 		if nil == dataFrame[fieldname] {
 			dataFrame[fieldname] = nil
 		}
@@ -104,7 +104,7 @@ func (operation *Operation) join(
 		/* build tuple */
 		tuple = make(map[string]interface{})
 		for fieldname, filedsArray := range dataFrame02 {
-			tuple[fieldname] = filedsArray[i]
+			tuple[fieldname] = filedsArray.([]interface{})[i]
 		}
 		dataSet02[GetKey(index02, tuple)] = tuple
 		operation.logger.Debug("Tuple - ", tuple, ", DataSet02 - ", dataSet02)
@@ -112,7 +112,7 @@ func (operation *Operation) join(
 
 	tupleSize = -1
 	for fieldname, filedsArray := range dataFrame01 {
-		tupleSize = len(filedsArray)
+		tupleSize = len(filedsArray.([]interface{}))
 		if nil == dataFrame[fieldname] {
 			dataFrame[fieldname] = nil
 		}
@@ -122,7 +122,7 @@ func (operation *Operation) join(
 	for i := 0; i < tupleSize; i++ {
 		tuple = make(map[string]interface{})
 		for fieldname, fieldsArray := range dataFrame01 {
-			tuple[fieldname] = fieldsArray[i]
+			tuple[fieldname] = fieldsArray.([]interface{})[i]
 		}
 
 		key := GetKey(index02, tuple)

--- a/operations/restructuring/join/operation_test.go
+++ b/operations/restructuring/join/operation_test.go
@@ -22,7 +22,7 @@ func Test1(t *testing.T) {
 	   In [81]: result = left.join(right)
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["left"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -35,7 +35,7 @@ func Test1(t *testing.T) {
 		"K0", "K1", "K2",
 	}
 
-	dataFrame = make(map[string][]interface{})
+	dataFrame = make(map[string]interface{})
 	inputs["right"] = dataFrame
 
 	dataFrame["C"] = []interface{}{
@@ -80,7 +80,7 @@ func Test2(t *testing.T) {
 	   In [81]: result = left.join(right)
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["left"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -93,7 +93,7 @@ func Test2(t *testing.T) {
 		"K0", "K1", "K2",
 	}
 
-	dataFrame = make(map[string][]interface{})
+	dataFrame = make(map[string]interface{})
 	inputs["right"] = dataFrame
 
 	dataFrame["C"] = []interface{}{
@@ -138,7 +138,7 @@ func Test3(t *testing.T) {
 	   In [81]: result = left.join(right)
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["left"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -151,7 +151,7 @@ func Test3(t *testing.T) {
 		"K0", "K1", "K2",
 	}
 
-	dataFrame = make(map[string][]interface{})
+	dataFrame = make(map[string]interface{})
 	inputs["right"] = dataFrame
 
 	dataFrame["C"] = []interface{}{
@@ -196,7 +196,7 @@ func Test4(t *testing.T) {
 	   In [81]: result = left.join(right)
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["left"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -209,7 +209,7 @@ func Test4(t *testing.T) {
 		"K0", "K1", "K2",
 	}
 
-	dataFrame = make(map[string][]interface{})
+	dataFrame = make(map[string]interface{})
 	inputs["right"] = dataFrame
 
 	dataFrame["C"] = []interface{}{

--- a/operations/restructuring/pivot/operation.go
+++ b/operations/restructuring/pivot/operation.go
@@ -39,32 +39,32 @@ func (operation *Operation) Eval(inputs map[string]interface{}) (interface{}, er
 	operation.logger.Debug("Input dataFrame is : ", in.Data)
 	operation.logger.Debug("Parameter is : ", operation.params)
 
-	result, err = operation.pivot(in.Data.(map[string][]interface{}))
+	result, err = operation.pivot(in.Data.(map[string]interface{}))
 
 	operation.logger.Debug("Pivoted dataFrame is : ", result)
 
 	return result, err
 }
 
-func (operation *Operation) pivot(dataFrame map[string][]interface{}) (result map[string][]interface{}, err error) {
+func (operation *Operation) pivot(dataFrame map[string]interface{}) (result map[string]interface{}, err error) {
 
 	/* check tuple size */
 	tupleSize := -1
 	for _, filedsArray := range dataFrame {
-		tupleSize = len(filedsArray)
+		tupleSize = len(filedsArray.([]interface{}))
 		if 0 < tupleSize {
 			break
 		}
 	}
 
-	newDataFrame := make(map[string][]interface{})
+	newDataFrame := make(map[string]interface{})
 	aggregatedTupleMap := make(map[common.Index]map[string]common.DataState)
 	tuple := make(map[string]interface{})
 	var key []interface{}
 	for i := 0; i < tupleSize; i++ {
 		/* build tuple */
 		for fieldname, filedsArray := range dataFrame {
-			tuple[fieldname] = filedsArray[i]
+			tuple[fieldname] = filedsArray.([]interface{})[i]
 		}
 
 		/* build key for output data*/
@@ -101,7 +101,7 @@ func (operation *Operation) pivot(dataFrame map[string][]interface{}) (result ma
 func (operation *Operation) aggregate(
 	tuple map[string]interface{},
 	aggregatedTuple map[string]common.DataState,
-	newDataFrame map[string][]interface{},
+	newDataFrame map[string]interface{},
 ) {
 	for valueColumn, functionNames := range operation.params.Aggregate {
 		for _, functionName := range functionNames {
@@ -138,7 +138,7 @@ func (operation *Operation) dataKey(
 
 func (operation *Operation) transform(
 	tupleMap map[common.Index]map[string]common.DataState,
-	newDataFrame map[string][]interface{}) (result map[string][]interface{}, err error) {
+	newDataFrame map[string]interface{}) (result map[string]interface{}, err error) {
 	counter := 0
 	for _, tuple := range tupleMap {
 		for column, columnValus := range newDataFrame {
@@ -147,7 +147,7 @@ func (operation *Operation) transform(
 				newDataFrame[column] = columnValus
 			}
 			if nil != tuple[column] {
-				columnValus[counter] = tuple[column].Value()
+				columnValus.([]interface{})[counter] = tuple[column].Value()
 			}
 		}
 		counter++

--- a/operations/restructuring/pivot/operation_test.go
+++ b/operations/restructuring/pivot/operation_test.go
@@ -20,7 +20,7 @@ func Test1(t *testing.T) {
 	       two    NaN    6.0
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -70,7 +70,7 @@ func Test2(t *testing.T) {
 	       small  2.333333  4.333333
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -123,7 +123,7 @@ func Test3(t *testing.T) {
 	       small  2.333333  6.0  4.333333  2.0
 	*/
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["A"] = []interface{}{
@@ -165,7 +165,7 @@ func Test4(t *testing.T) {
 	/*
 	 */
 	inputs := make(map[string]interface{})
-	dataFrame := make(map[string][]interface{})
+	dataFrame := make(map[string]interface{})
 	inputs["data"] = dataFrame
 
 	dataFrame["A"] = []interface{}{


### PR DESCRIPTION
Since sort operation sorts both by column (axis = 0) and by row (axis = 1), we need a way to represent the order of row. This modification only for making DataFrame keep the order of its columns.