### PR TITLE
Generalizing reshape operation

### DIFF
--- a/operations/restructuring/reshape/operation.go
+++ b/operations/restructuring/reshape/operation.go
@@ -1,6 +1,8 @@
 package reshape
 
 import (
+	"fmt"
+
 	"github.com/project-flogo/catalystml-flogo/action/operation"
 	"github.com/project-flogo/core/data/coerce"
 	"github.com/project-flogo/core/support/log"
@@ -16,44 +18,94 @@ func New(ctx operation.InitContext) (operation.Operation, error) {
 }
 
 func (a *Operation) Eval(inputs map[string]interface{}) (interface{}, error) {
-	var row, column int
-	var result [][]interface{}
+	// var row, column int
+	// var result [][]interface{}
 	in := &Input{}
 
 	in.FromMap(inputs)
 	a.logger.Info("Starting Operation reshape.")
-	a.logger.Debug("The inputs for operation reshape.", in.Data)
+	a.logger.Debug("The inputs for operation reshape. Data=", in.Data)
+	a.logger.Debug("The inputs for operation reshape. Shape=", in.Shape)
 	flatData, _ := coerce.ToArray(flattenArr(in.Data))
 
-	if len(in.Shape) < 3 {
+	a.logger.Info("shape length: ", len(in.Shape))
 
-		row, _ = coerce.ToInt(in.Shape[0])
-		column, _ = coerce.ToInt(in.Shape[1])
-	}
-	if row == -1 {
-		return flatData, nil
-	}
-	if row > 0 && column <= 0 {
-		rowCap := len(flatData) / row
-		for i := 0; i < row; i++ {
-			temp, _ := coerce.ToArray(flatData[:rowCap])
-			result = append(result, temp)
-			flatData = flatData[rowCap:]
+	// Checking that there aren't too many -1 values (more than 1)
+	negs := 0
+	ind := -1
+	denom := 1
+	for i, l := range in.Shape {
+		lo, _ := coerce.ToInt(l)
+		if lo < 0 {
+			negs++
+			ind = i
+		} else if lo == 0 {
+			return nil, fmt.Errorf("shape values of 0 are not valid")
+		} else {
+			denom *= lo
 		}
-		return result, nil
+	}
+	if negs > 1 {
+		return nil, fmt.Errorf("more than one shape values are -1 which is not allowed")
 	}
 
-	for i := 0; i < row; i++ {
-		temp, _ := coerce.ToArray(flatData[:column])
-		result = append(result, temp)
-		flatData = flatData[column:]
+	// Now that we know there is only one -1 . . . get the new value
+	if ind >= 0 {
+		newShape := float32(len(flatData)) / float32(denom)
+		if newShape == float32(int32(newShape)) {
+			in.Shape[ind] = newShape
+		} else {
+			return nil, fmt.Errorf("the value replacing -1 is not an integer")
+		}
+		a.logger.Info("Adusted shape array is:", in.Shape)
+
+	}
+
+	//building tensor see below recursive function
+	tensor, err := constructTensor(flatData, in.Shape)
+	if err != nil {
+		return nil, err
 	}
 	a.logger.Info("Operation reshape completed.")
-	a.logger.Debug("The output for operation reshape.", result)
+	a.logger.Debug("The output for operation reshape.", tensor)
 
-	return result, nil
+	return tensor, nil
 }
 
+//Returns the multiple of all the integers in an array
+func mul(arr []interface{}) (s int32) {
+	s = 1
+	for _, l := range arr {
+		lo, _ := coerce.ToInt32(l)
+		s *= lo
+	}
+	return s
+}
+
+// recursively builds array
+func constructTensor(array []interface{}, shp []interface{}) (tensor []interface{}, err error) {
+
+	arr := array
+	dim, _ := coerce.ToInt32(shp[0])
+	// Testing stop condition
+	if len(shp) == 1 {
+		return arr, nil
+	}
+
+	//self call in a loop of each dimension appended to tensor
+	for i := int32(0); i < dim; i++ {
+		rowCap := mul(shp[1:])
+		t, err := constructTensor(arr[:rowCap], shp[1:])
+		if err != nil {
+			return nil, err
+		}
+		tensor = append(tensor, t)
+		arr = arr[rowCap:]
+	}
+	return tensor, nil
+}
+
+//Flattens a tensor in and flattens it.
 func flattenArr(multiArr []interface{}) interface{} {
 	var result []interface{}
 

--- a/operations/restructuring/reshape/operation.go
+++ b/operations/restructuring/reshape/operation.go
@@ -18,8 +18,6 @@ func New(ctx operation.InitContext) (operation.Operation, error) {
 }
 
 func (a *Operation) Eval(inputs map[string]interface{}) (interface{}, error) {
-	// var row, column int
-	// var result [][]interface{}
 	in := &Input{}
 
 	in.FromMap(inputs)

--- a/operations/restructuring/reshape/operation_test.go
+++ b/operations/restructuring/reshape/operation_test.go
@@ -2,22 +2,22 @@ package reshape
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/project-flogo/core/data/coerce"
 	"github.com/project-flogo/core/support/log"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSimple(t *testing.T) {
 	//params := Params{}
-	opt := &Operation{logger : log.RootLogger() }
-	val, err := coerce.ToArray([]int{1,3,45,5})
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([]int{1, 3, 45, 5})
 	inputs := make(map[string]interface{})
 	inputs["data"] = val
-	inputs["shape"] = []int{2,2}
+	inputs["shape"] = []int{2, 2}
 
 	//input := &Input{Array: []float32{1.0, 2.0, 3.6, 4}}
-
 
 	result, err := opt.Eval(inputs)
 
@@ -25,16 +25,33 @@ func TestSimple(t *testing.T) {
 	fmt.Println("Result...", result)
 
 }
+
+func TestAllNegOne(t *testing.T) {
+	//params := Params{}
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([]int{1, 3, 45, 5})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+	inputs["shape"] = []int{-1, -1, -1}
+
+	//input := &Input{Array: []float32{1.0, 2.0, 3.6, 4}}
+
+	_, err = opt.Eval(inputs)
+
+	assert.NotNil(t, err)
+	fmt.Println("Expected error . . .", err)
+
+}
+
 func TestSingleRow(t *testing.T) {
 	//params := Params{}
-	opt := &Operation{logger : log.RootLogger() }
-	val, err := coerce.ToArray([]int{1,3,45,5})
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([]int{1, 3, 45, 5})
 	inputs := make(map[string]interface{})
 	inputs["data"] = val
-	inputs["shape"] = []int{4,-1}
+	inputs["shape"] = []int{4, -1}
 
 	//input := &Input{Array: []float32{1.0, 2.0, 3.6, 4}}
-
 
 	result, err := opt.Eval(inputs)
 
@@ -42,14 +59,91 @@ func TestSingleRow(t *testing.T) {
 	fmt.Println("Result...", result)
 
 }
-func TestMultiRe(t *testing.T) {
-	opt := &Operation{logger : log.RootLogger() }
-	val, err := coerce.ToArray([][]int{{1,1},{2,2},{3,3},{4,4}})
+func TestInvalidGuess(t *testing.T) {
+	//params := Params{}
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([]int{1, 3, 45, 5, 9})
 	inputs := make(map[string]interface{})
 	inputs["data"] = val
-	
-	inputs["shape"]= []int{2,4}
-	
+	inputs["shape"] = []int{2, -1}
+
+	//input := &Input{Array: []float32{1.0, 2.0, 3.6, 4}}
+
+	_, err = opt.Eval(inputs)
+
+	assert.NotNil(t, err)
+	fmt.Println("Expected error . . .", err)
+
+}
+
+func TestMultiRe(t *testing.T) {
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([][]int{{1, 1}, {2, 2}, {3, 3}, {4, 4}})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+
+	inputs["shape"] = []int{2, 4}
+
+	result, err := opt.Eval(inputs)
+
+	assert.Nil(t, err)
+	fmt.Println("Result...", result)
+
+}
+
+func Test3DIn(t *testing.T) {
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([][][]int{{{1}, {1}}, {{2}, {2}}, {{3}, {3}}, {{4}, {4}}})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+
+	inputs["shape"] = []int{2, 4}
+
+	result, err := opt.Eval(inputs)
+
+	assert.Nil(t, err)
+	fmt.Println("Result...", result)
+
+}
+
+func Test3DOut(t *testing.T) {
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([][]int{{1, 1}, {2, 2}, {3, 3}, {4, 4}})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+
+	inputs["shape"] = []int{2, 4, -1}
+
+	result, err := opt.Eval(inputs)
+
+	assert.Nil(t, err)
+	fmt.Println("Result...", result)
+
+}
+
+func Test3DOut2(t *testing.T) {
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([][]int{{1, 1}, {2, 2}, {3, 3}, {4, 4}})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+
+	inputs["shape"] = []int{2, -1, 4}
+
+	result, err := opt.Eval(inputs)
+
+	assert.Nil(t, err)
+	fmt.Println("Result...", result)
+
+}
+
+func Test4DOut(t *testing.T) {
+	opt := &Operation{logger: log.RootLogger()}
+	val, err := coerce.ToArray([][][][]int{{{{1, 2}}, {{1, 2}}}, {{{2, 3}}, {{2, 3}}}, {{{3, 4}}, {{3, 4}}}, {{{4, 5}}, {{4, 5}}}})
+	inputs := make(map[string]interface{})
+	inputs["data"] = val
+
+	inputs["shape"] = []int{1, 1, 4, -1}
+
 	result, err := opt.Eval(inputs)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
Previously reshape was only for matrices.  Now it works for an arbitrary rank tensor.